### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,14 +3,9 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore: 
-      - _infra/spinnaker/**
-      - _infra/helm/sample-file-uploader/Chart.yaml
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - _infra/spinnaker/**
-      - _infra/helm/sample-file-uploader/Chart.yaml
+
 env:
   IMAGE: sample-file-uploader
   REGISTRY_HOSTNAME: eu.gcr.io
@@ -144,7 +139,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           make
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
         env:
           GOPATH: /home/runner/work/ras-rm-sample-file-uploader/go
           GOOS: linux
@@ -154,6 +149,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
 
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/sample-file-uploader/Chart.yaml
+++ b/_infra/helm/sample-file-uploader/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.23
+appVersion: 0.0.24


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.

# How to test?

# Trello
