### PR TITLE
Use recommended tag for setup-gcloud

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@main
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GOPATH: /home/runner/work/ras-rm-sample-file-uploader/go
 
-      - uses: google-github-actions/setup-gcloud@main
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '270.0.0'
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/_infra/helm/sample-file-uploader/Chart.yaml
+++ b/_infra/helm/sample-file-uploader/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.3
+appVersion: 1.0.4


### PR DESCRIPTION
# What and why?

In the last PR, it was changed to use `google-github-actions/setup-gcloud@main`.  In the test run, it actively warns against using this.  This PR changes it so the recommended `v0` tag.

# How to test?

# Trello
