### PR TITLE
Fix security account key deprecation

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,17 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
+      - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          export_default_credentials: true
-          
       - uses: onsdigital/ras-rm-spinnaker-action@main
         with:
           comment-body: ${{ github.event.comment.body }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,10 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
           export_default_credentials: true
           
       - uses: onsdigital/ras-rm-spinnaker-action@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,10 @@ jobs:
           GOPATH: /home/runner/work/ras-rm-sample-file-uploader/go
 
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,13 @@ jobs:
         env:
           GOPATH: /home/runner/work/ras-rm-sample-file-uploader/go
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
         with:
-          version: '270.0.0'
-          service_account_key: ${{ secrets.GCR_KEY }}
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
       - run: |
           gcloud auth configure-docker
 

--- a/_infra/helm/sample-file-uploader/Chart.yaml
+++ b/_infra/helm/sample-file-uploader/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.4
+appVersion: 1.0.5


### PR DESCRIPTION
# What and why?
This PR updates Github actions to fix "service_account_key" has been deprecate. Replacing it with google-github-actions/auth in both main.yml and comment.yml
# How to test?
For main.yml check https://github.com/ONSdigital/ras-rm-sample-file-uploader/runs/7212181454?check_suite_focus=true
For comment.yml see https://github.com/ONSdigital/response-operations-ui/pull/747 on how I tested in response-operations, as it is a virtual copy bar the service I didn't repeat it here